### PR TITLE
Migrate to role-based contact emails and add housekeeping docs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,11 @@
+# Funding configuration for this repository.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# Uncomment and fill in the platforms you use. Multiple platforms are supported.
+
+# github: [mdavistffhrtporg]
+# ko_fi: # Replace with a single Ko-fi username
+# buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+# liberapay: # Replace with a single Liberapay username
+# patreon: # Replace with a single Patreon username
+# custom: # Replace with up to 4 custom sponsorship URLs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Thanks for opening a pull request! Please complete the sections below.
+For security issues, do not open a PR — see SECURITY.md.
+-->
+
+## Summary
+
+<!-- What does this change do? Why is it needed? -->
+
+## Type of Change
+
+- [ ] Content update (post, page, copy fix)
+- [ ] Bug fix
+- [ ] Feature or enhancement
+- [ ] Infrastructure / build / CI
+- [ ] Documentation
+- [ ] Other (describe):
+
+## Related Issues
+
+<!-- Link related issues, e.g. "Closes #123" -->
+
+## Checklist
+
+- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
+- [ ] I have added an entry under `[Unreleased]` in `CHANGELOG.md` for any user-facing change.
+- [ ] I have built the site locally (`hugo server`) and verified there are no rendering or link issues.
+- [ ] I have not introduced trackers, third-party analytics, or non-essential external resources.
+- [ ] My changes generate no new warnings or build errors.
+
+## Screenshots / Notes
+
+<!-- Optional: screenshots for visual changes, or additional context for reviewers. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `CHANGELOG.md` following Keep a Changelog conventions.
+- `CONTRIBUTING.md` with contribution guidelines, PR process, and local development instructions.
+- `CODE_OF_CONDUCT.md` adopting the Contributor Covenant 3.0.
+- `.github/PULL_REQUEST_TEMPLATE.md` to standardize pull request submissions.
+- `.github/FUNDING.yml` (commented stub) for optional repository sponsorship configuration.
+
+### Changed
+- Replaced personal contact email (`matthewd@matthewd.xyz`) with role-based addresses:
+  - `security.txt` now lists `security@matthewd.xyz` and `security@mlaify.io`.
+  - `privacy.json` now lists `privacy@matthewd.xyz`.
+  - `humans.txt` general contact updated to `privacy@matthewd.xyz`.
+- Migrated remaining `matthewd.org` references to `matthewd.xyz` in privacy policy and post cover captions.
+- Privacy policy "Exercising Your Rights" contact updated to `privacy@matthewd.xyz`.
+- Code of Conduct "Reporting" contact updated to `security@matthewd.xyz`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, email [security@matthewd.xyz](mailto:security@matthewd.xyz). Reports will be reviewed and handled with discretion.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/).
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thank you for your interest in contributing to `matthewd.xyz`. This site is a personal Hugo-based static site, but improvements, corrections, and suggestions are welcome.
+
+By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to Contribute
+
+- **Report a bug or content issue** — open an issue using the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md).
+- **Suggest a feature or improvement** — open an issue using the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md).
+- **Fix a typo or update content** — open a pull request directly.
+- **Report a security vulnerability** — **do not open a public issue.** Follow the disclosure process in [`SECURITY.md`](SECURITY.md).
+
+## Pull Request Process
+
+1. Fork the repository and create a topic branch from `main`.
+2. Make your changes. Keep them focused and scoped to a single purpose where possible.
+3. Add an entry under `[Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md) for any user-facing change, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions.
+4. Verify the site builds locally with `hugo server` and that no broken links or rendering issues are introduced.
+5. Open a pull request against `main` using the PR template. Describe what changed and why.
+6. Be responsive to review feedback. Squash or fixup commits as requested before merge.
+
+## Style and Content Guidelines
+
+- **Markdown:** Use standard CommonMark/Hugo-flavored markdown. Keep front matter consistent with existing posts.
+- **Images:** Place post-specific images in the post bundle directory (e.g. `content/posts/post-N/images/`). Provide descriptive `alt` text.
+- **Tone:** Match the existing voice of the site — direct, technical, and considerate.
+- **Privacy:** Do not introduce trackers, third-party analytics, or external resources without discussion. The site is intentionally privacy-respecting and static-first.
+
+## Local Development
+
+```sh
+# Clone with submodules (PaperMod theme)
+git clone --recurse-submodules https://github.com/mdavistffhrtporg/mdavistffhrtporg.github.io.git
+cd mdavistffhrtporg.github.io
+
+# Run a local dev server
+hugo server -D
+```
+
+The site will be available at `http://localhost:1313/`.
+
+## Licensing
+
+By contributing, you agree that your contributions will be licensed under the terms of the project:
+
+- Code and configuration: [MIT License](LICENSE)
+- Written content and original media: [CC BY-NC-SA 4.0](CONTENT_LICENSE.md)

--- a/content/posts/post-6/d-850-thoughts.md
+++ b/content/posts/post-6/d-850-thoughts.md
@@ -22,7 +22,7 @@ searchHidden: false
 cover:
   image: "images/D850642_2560w_shorter.jpeg"
   alt: "black and white image of an adult and child walking on an old, out of service, train track"
-  caption: "_Photo by: [Me](https://matthewd.org/) on [Instagram](https://instagram.com/mattdmattphoto)_"
+  caption: "_Photo by: [Me](https://matthewd.xyz/) on [Instagram](https://instagram.com/mattdmattphoto)_"
   relative: false
   hidden: false
 ---

--- a/content/posts/post-6/index.md
+++ b/content/posts/post-6/index.md
@@ -22,7 +22,7 @@ searchHidden: false
 cover:
   image: "images/D850642_2560w_shorter.jpeg"
   alt: "black and white image of an adult and child walking on an old, out of service, train track"
-  caption: "_Photo by: [Me](https://matthewd.org/) on [Instagram](https://instagram.com/mattdmattphoto)_"
+  caption: "_Photo by: [Me](https://matthewd.xyz/) on [Instagram](https://instagram.com/mattdmattphoto)_"
   relative: false
   hidden: false
 ---

--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -26,7 +26,7 @@ comments: false
 
 ## Overview
 
-This website (`matthewd.org`) is a personal website operated by Matthew Davis.
+This website (`matthewd.xyz`) is a personal website operated by Matthew Davis.
 
 The site is designed to be simple, secure, and respectful of visitor privacy. It does not sell personal data, does not run advertising networks, and does not engage in behavioral profiling or targeted advertising.
 
@@ -156,7 +156,7 @@ This website processes only limited technical data necessary for secure operatio
 
 You may contact the site operator regarding privacy-related requests:
 
-- **Email:** matthewd@matthewd.org  
+- **Email:** privacy@matthewd.xyz  
 - **GitHub:** By opening an issue in a related GitHub repository
 
 Because this site does not maintain user accounts or personal profiles, the ability to identify or act on specific data may be limited.
@@ -261,7 +261,7 @@ Violations may result in moderation actions, including content removal or partic
 ## Reporting
 
 Concerns may be reported via:
-- **Email:** matthewd@matthewd.org  
+- **Email:** security@matthewd.xyz  
 - **GitHub:** By filing an issue or contacting repository maintainers
 
 All reports will be reviewed and handled with discretion.

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,8 +1,8 @@
 # Matthew Davis security contacts and policy
 
 # Our security contact channels
-Contact: mailto:matthewd@matthewd.xyz
-Contact: mailto:mdavisa2021@pm.me
+Contact: mailto:security@matthewd.xyz
+Contact: mailto:security@mlaify.io
 
 # If practical, use PGP encryption
 Encryption: https://raw.githubusercontent.com/mdavistffhrtporg/mdavistffhrtporg.github.io/refs/heads/main/static/matthewdxyz.asc

--- a/static/humans.txt
+++ b/static/humans.txt
@@ -1,6 +1,6 @@
 /* TEAM */
 Owner / Author: Matthew Davis
-Contact: matthewd@matthewd.xyz
+Contact: privacy@matthewd.xyz
 GitHub: https://github.com/mdavistffhrtporg
 Location: United States
 

--- a/static/privacy.json
+++ b/static/privacy.json
@@ -32,7 +32,7 @@
     "Texas TDPSA"
   ],
   "contact": {
-    "email": "matthewd@matthewd.xyz",
+    "email": "privacy@matthewd.xyz",
     "github": "https://github.com/mdavistffhrtporg"
   }
 }


### PR DESCRIPTION
## Summary

- Replace personal contact emails (`matthewd@matthewd.xyz`, `mdavisa2021@pm.me`) with role-based addresses across `security.txt`, `privacy.json`, `humans.txt`, and the privacy policy.
- Migrate remaining `matthewd.org` references to `matthewd.xyz` in `privacy-policy.md` and post cover captions (`post-6`).
- Add the standard GitHub housekeeping doc set: `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 3.0), `.github/PULL_REQUEST_TEMPLATE.md`, and a commented `.github/FUNDING.yml` stub.

### Email mapping

| Surface | Before | After |
|---|---|---|
| `security.txt` (security contacts) | `matthewd@matthewd.xyz`, `mdavisa2021@pm.me` | `security@matthewd.xyz`, `security@mlaify.io` |
| `privacy.json` (privacy contact) | `matthewd@matthewd.xyz` | `privacy@matthewd.xyz` |
| `humans.txt` (general contact) | `matthewd@matthewd.xyz` | `privacy@matthewd.xyz` |
| Privacy Policy → "Exercising Your Rights" | `matthewd@matthewd.org` | `privacy@matthewd.xyz` |
| Privacy Policy → CoC "Reporting" | `matthewd@matthewd.org` | `security@matthewd.xyz` |

### Out of scope (intentionally left alone per author)

- `CNAME` still lists `matthewd.org` (handled separately).
- `old_sitemap.txt` retains historical `.org` URLs.

## Test plan

- [ ] `hugo server` builds without errors and the privacy policy renders correctly with updated contact addresses.
- [ ] `static/.well-known/security.txt` is reachable at `/.well-known/security.txt` and lists the new security addresses.
- [ ] `static/privacy.json` and `static/humans.txt` resolve correctly at their canonical paths.
- [ ] GitHub renders `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and the PR template on this PR's preview.
- [ ] CHANGELOG `[Unreleased]` entry accurately reflects the changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)