### PR TITLE
Cleanup: tagline, OG image, Aegis repo URL, Hugo deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/posts/` renamed to `/writing/`. Old URLs (`/posts/<slug>/`) 301-redirect via Hugo aliases. `/archives/` → `/writing/`.
 - `/me/` renamed to `/about/`. Old URL redirects via alias. Body rewritten to remove the "professional photographer" lead (medical retirement), merge mlaify's umbrella copy in first-person, and link to `/principles/` for the longer story.
 - Top nav: Writing · Projects · About (was Posts · About). Footer gains Projects, Principles, and Contribute entries.
+- Site tagline shortened to "Open source contributor and writer." Description aligned.
+- Aegis `repoUrl` in `params.toml` now points to `mlaify/aegis-spec` (the protocol RFC repo) rather than a non-existent `mlaify/aegis`.
+- OG default image points at `images/pic-mdavis-home.svg` until a dedicated 1200×630 PNG is designed.
+- `config/_default/languages.toml` uses `locale`/`label` (Hugo ≥ 0.158 keys) instead of the deprecated `languageCode`/`languageName`.
 
 ### Removed
 - PaperMod theme submodule.

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -1,4 +1,4 @@
 [en]
-  languageName = "English"
-  languageCode = "en-US"
+  label = "English"
+  locale = "en-US"
   weight = 1

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,8 +1,8 @@
-description = "Matthew A. Davis — open-source contributor, writer at Fedora Magazine, builds security-first tooling."
-tagline = "OSS contributor · Writer at Fedora Magazine · Builds security-first tooling"
+description = "Matthew A. Davis — open source contributor and writer."
+tagline = "Open source contributor and writer."
 
 # Default OG / Twitter image
-ogImage = "images/og-default.png"
+ogImage = "images/pic-mdavis-home.svg"
 twitterHandle = ""
 
 # Repo / org links
@@ -32,7 +32,7 @@ showBuildInfo = false
     status = "alpha"
     accent = "aegis"
     url = "/aegis/"
-    repoUrl = "https://github.com/mlaify/aegis"
+    repoUrl = "https://github.com/mlaify/aegis-spec"
     weight = 10
 
   [products.attackmap]


### PR DESCRIPTION
## Summary

Four small follow-ups from the Phase 1/2 PRs, batched:

- **Tagline** shortened to *"Open source contributor and writer."* (was "OSS contributor · Writer at Fedora Magazine · Builds security-first tooling.")
- **Aegis `repoUrl`**: `mlaify/aegis` (non-existent) → `mlaify/aegis-spec` (the protocol RFC repo — canonical entry among the ~18 Aegis-* repos)
- **OG default image**: `images/og-default.png` (didn't exist) → `images/pic-mdavis-home.svg`
- **Hugo deprecations**: `languageCode` → `locale`, `languageName` → `label` in `config/_default/languages.toml`. Clears the two persistent WARN lines in CI.

## Test plan

- [ ] CI passes
- [ ] No more `WARN deprecated` lines in the build output
- [ ] Homepage hero shows the new tagline
- [ ] `<meta property="og:image">` resolves to a real file

🤖 Generated with [Claude Code](https://claude.com/claude-code)