### PR TITLE
Phase 3: mlaify.io redirects + sunset + Hugo aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aegis `repoUrl` in `params.toml` now points to `mlaify/aegis-spec` (the protocol RFC repo) rather than a non-existent `mlaify/aegis`.
 - OG default image points at `images/pic-mdavis-home.svg` until a dedicated 1200×630 PNG is designed.
 - `config/_default/languages.toml` uses `locale`/`label` (Hugo ≥ 0.158 keys) instead of the deprecated `languageCode`/`languageName`.
+- `CNAME` updated to a new 10-domain set: `matthewd.xyz`, `matthewd.org`, `fhrp.org`, `mlaify.io`, `mdavis.me`, `mldavis.me`, `mlphotography.me`, `rightsarchived.org`, `rightsinfocus.org`, `tffhrtp.org`. mlaify.io is now claimed by this repo's GH Pages so the mlaify org repo could be archived without losing the domain.
+- mlaify.io paths now 301-redirect to matthewd.xyz via Cloudflare Bulk Redirects (Phase 3). The redirect list is checked into `docs/superpowers/ops/cloudflare-redirects-mlaify-io.csv`; the runbook is at `docs/superpowers/ops/phase-3-runbook.md`. Cloudflare's Bulk Redirects feature does not rewrite paths (only swaps hosts), so the 5 path-changing cases (`/build-principles/` → `/principles/`, `/docs/project-*` → `/<project>/`, `/privacy/` → `/privacy-policy/`) use Hugo `aliases` for the second hop.
+- `mlaify/mlaify.github.io` repo archived as defense-in-depth (origin still serves a "moved" notice if a Cloudflare rule ever misses).
 
 ### Removed
 - PaperMod theme submodule.
@@ -42,3 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `content/search.md` (PaperMod Fuse-based search page; replaced by Pagefind).
 - `content/posts/` directory (moved to `content/writing/`).
 - `content/me.md` (folded into `content/about/_index.md`).
+- Side domains opensift.org and siftbook.org sunset (CNAME claim removed from mlaify.github.io, DNS records deleted in Cloudflare).
+- `callmemattd.com` and `littleabigails.com` no longer claimed by this repo's GH Pages (removed from CNAME).

--- a/CNAME
+++ b/CNAME
@@ -1,7 +1,10 @@
-matthewd.org
 matthewd.xyz
-callmemattd.com
-littleabigails.com
+matthewd.org
+fhrp.org
+mlaify.io
 mdavis.me
 mldavis.me
 mlphotography.me
+rightsarchived.org
+rightsinfocus.org
+tffhrtp.org

--- a/content/omekarapper/_index.md
+++ b/content/omekarapper/_index.md
@@ -7,6 +7,8 @@ draft: false
 weight: 40
 toc: true
 status: "alpha"
+aliases:
+  - /docs/project-omekarapper/
 ---
 
 {{< status "alpha" >}}

--- a/content/opencontractrx/_index.md
+++ b/content/opencontractrx/_index.md
@@ -7,6 +7,8 @@ draft: false
 weight: 60
 toc: true
 status: "alpha"
+aliases:
+  - /docs/project-opencontractrx/
 ---
 
 Repository: [mlaify/OpenContractRx](https://github.com/mlaify/OpenContractRx)

--- a/content/opensift/_index.md
+++ b/content/opensift/_index.md
@@ -7,6 +7,8 @@ draft: false
 weight: 50
 toc: true
 status: "alpha"
+aliases:
+  - /docs/project-opensift/
 ---
 
 Repository: [mlaify/OpenSift](https://github.com/mlaify/OpenSift)

--- a/content/principles/_index.md
+++ b/content/principles/_index.md
@@ -8,6 +8,8 @@ weight: 20
 toc: true
 sidebar: false
 lead: "The five conventions every project of mine follows."
+aliases:
+  - /build-principles/
 ---
 
 These are not aspirational. They are the conventions every project of mine actually follows. If a project on this site appears to violate one of them, it's a bug — file an issue.

--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -2,8 +2,10 @@
 title: "Privacy Policy, Terms of Use, and Code of Conduct"
 
 description: "Privacy Policy, Terms of Use, and Code of Conduct"
+aliases:
+  - /privacy/
 cascade:
-comments: false
+  comments: false
 ---
 
 # Privacy Policy, Terms of Use, and Code of Conduct

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -4,6 +4,9 @@ description: "Open source software I build — security tooling, AI-assisted wor
 date: 2026-06-03T00:00:00-05:00
 draft: false
 comments: false
+aliases:
+  - /docs/projects/
+  - /docs/
 ---
 
 Two flagship projects (Aegis and AttackMap) sit alongside a few smaller ones. Each carries an honest status — alpha means alpha. See [build principles](/principles/) for the longer story on how I work.

--- a/docs/superpowers/ops/cloudflare-redirects-mlaify-io.csv
+++ b/docs/superpowers/ops/cloudflare-redirects-mlaify-io.csv
@@ -1,0 +1,17 @@
+source_url,target_url,status,preserve_query_string,subpath_matching,preserve_path_suffix,include_subdomains
+mlaify.io/aegis/,https://matthewd.xyz/aegis/,301,true,true,true,false
+mlaify.io/attackmap/,https://matthewd.xyz/attackmap/,301,true,true,true,false
+mlaify.io/docs/project-omekarapper/,https://matthewd.xyz/omekarapper/,301,true,true,true,false
+mlaify.io/docs/project-opensift/,https://matthewd.xyz/opensift/,301,true,true,true,false
+mlaify.io/docs/project-opencontractrx/,https://matthewd.xyz/opencontractrx/,301,true,true,true,false
+mlaify.io/docs/projects/,https://matthewd.xyz/projects/,301,true,false,false,false
+mlaify.io/docs/,https://matthewd.xyz/projects/,301,true,false,false,false
+mlaify.io/build-principles/,https://matthewd.xyz/principles/,301,true,true,true,false
+mlaify.io/contribute/,https://matthewd.xyz/contribute/,301,true,true,true,false
+mlaify.io/about/,https://matthewd.xyz/about/,301,true,true,true,false
+mlaify.io/privacy/,https://matthewd.xyz/privacy-policy/,301,true,false,false,false
+mlaify.io/security/,https://matthewd.xyz/security/,301,true,true,true,false
+mlaify.io/.well-known/security.txt,https://matthewd.xyz/.well-known/security.txt,301,false,false,false,false
+mlaify.io/humans.txt,https://matthewd.xyz/humans.txt,301,false,false,false,false
+mlaify.io/privacy.json,https://matthewd.xyz/privacy.json,301,false,false,false,false
+mlaify.io/,https://matthewd.xyz/projects/,301,true,true,true,false

--- a/docs/superpowers/ops/cloudflare-redirects-mlaify-io.csv
+++ b/docs/superpowers/ops/cloudflare-redirects-mlaify-io.csv
@@ -1,12 +1,12 @@
 source_url,target_url,status,preserve_query_string,subpath_matching,preserve_path_suffix,include_subdomains
 mlaify.io/aegis/,https://matthewd.xyz/aegis/,301,true,true,true,false
 mlaify.io/attackmap/,https://matthewd.xyz/attackmap/,301,true,true,true,false
-mlaify.io/docs/project-omekarapper/,https://matthewd.xyz/omekarapper/,301,true,true,true,false
-mlaify.io/docs/project-opensift/,https://matthewd.xyz/opensift/,301,true,true,true,false
-mlaify.io/docs/project-opencontractrx/,https://matthewd.xyz/opencontractrx/,301,true,true,true,false
+mlaify.io/docs/project-omekarapper/,https://matthewd.xyz/omekarapper/,301,true,false,false,false
+mlaify.io/docs/project-opensift/,https://matthewd.xyz/opensift/,301,true,false,false,false
+mlaify.io/docs/project-opencontractrx/,https://matthewd.xyz/opencontractrx/,301,true,false,false,false
 mlaify.io/docs/projects/,https://matthewd.xyz/projects/,301,true,false,false,false
 mlaify.io/docs/,https://matthewd.xyz/projects/,301,true,false,false,false
-mlaify.io/build-principles/,https://matthewd.xyz/principles/,301,true,true,true,false
+mlaify.io/build-principles/,https://matthewd.xyz/principles/,301,true,false,false,false
 mlaify.io/contribute/,https://matthewd.xyz/contribute/,301,true,true,true,false
 mlaify.io/about/,https://matthewd.xyz/about/,301,true,true,true,false
 mlaify.io/privacy/,https://matthewd.xyz/privacy-policy/,301,true,false,false,false
@@ -14,4 +14,4 @@ mlaify.io/security/,https://matthewd.xyz/security/,301,true,true,true,false
 mlaify.io/.well-known/security.txt,https://matthewd.xyz/.well-known/security.txt,301,false,false,false,false
 mlaify.io/humans.txt,https://matthewd.xyz/humans.txt,301,false,false,false,false
 mlaify.io/privacy.json,https://matthewd.xyz/privacy.json,301,false,false,false,false
-mlaify.io/,https://matthewd.xyz/projects/,301,true,true,true,false
+mlaify.io/,https://matthewd.xyz/projects/,301,true,false,false,false

--- a/docs/superpowers/ops/phase-3-runbook.md
+++ b/docs/superpowers/ops/phase-3-runbook.md
@@ -65,6 +65,28 @@ If any rule misses (you see a 200 or the wrong location), open the Cloudflare da
 - `preserve_path_suffix` toggle not enabled.
 - Source URL has a different trailing slash than what was uploaded.
 
+### Path-rewriting rules: subpath_matching must be **false**
+
+**Important Cloudflare semantic:** when `subpath_matching=true` AND `preserve_path_suffix=true`, Cloudflare effectively *ignores the target URL's path component* — it only swaps the host. This works when the source path equals the target path (e.g. `/aegis/` → `/aegis/`), but breaks for rules where the path itself changes (e.g. `/build-principles/` → `/principles/` would actually resolve to `/build-principles/` on the new host).
+
+The CSV's 4 path-rewriting rules therefore use `subpath_matching=false` + `preserve_path_suffix=false` (exact-match):
+
+- `/build-principles/` → `/principles/`
+- `/docs/project-omekarapper/` → `/omekarapper/`
+- `/docs/project-opensift/` → `/opensift/`
+- `/docs/project-opencontractrx/` → `/opencontractrx/`
+- `/` (catchall) → `/projects/`
+
+Trade-off: these rules now match only the exact URL — no sub-paths. In practice none of those source URLs have children (each was a single page on mlaify.io), so this is fine. Any unknown sub-path falls through to the GH Pages origin, which now serves matthewd.xyz content (matthewd's CNAME claims mlaify.io as an alias), so a request to e.g. `mlaify.io/build-principles/anything-unknown` lands on matthewd's 404 page.
+
+If the initial CSV was uploaded with the buggy toggle settings, fix in the dashboard:
+
+1. Open the List `mlaify-io-sunset`.
+2. Edit each of the 5 rules above.
+3. Toggle **Subpath matching** to **OFF** and **Preserve path suffix** to **OFF**.
+4. Save.
+5. Re-run the smoke test from Step 4 above — all should now redirect to the rewritten target.
+
 ## Step 5: Remove DNS records for opensift.org and siftbook.org
 
 Both side domains were CNAME'd at GitHub Pages via the mlaify.github.io repo's CNAME file. After plan Task 4 trims that CNAME, those domains stop being claimed by GH Pages. The DNS records also need removing.

--- a/docs/superpowers/ops/phase-3-runbook.md
+++ b/docs/superpowers/ops/phase-3-runbook.md
@@ -1,0 +1,105 @@
+# Phase 3 Runbook — mlaify.io Redirects & DNS Sunset
+
+This runbook walks through the manual Cloudflare changes for Phase 3 of the matthewd.xyz × mlaify merge.
+
+The CSV used in Step 2 is at `cloudflare-redirects-mlaify-io.csv` in this directory.
+
+## Prerequisites
+
+- Cloudflare dashboard access for the `mlaify.io` zone.
+- Cloudflare dashboard access for the `opensift.org` zone.
+- Cloudflare dashboard access for the `siftbook.org` zone.
+- The CSV file `cloudflare-redirects-mlaify-io.csv` open in another tab — you'll upload it.
+
+## Step 1: Verify Cloudflare account state
+
+In the Cloudflare dashboard, confirm all three zones (`mlaify.io`, `opensift.org`, `siftbook.org`) are present and active. If any are on a different account, this runbook assumes single-account access.
+
+## Step 2: Create the Bulk Redirects List
+
+Cloudflare's Bulk Redirects has two parts: **Lists** (the redirect entries) and **Rules** (which lists apply to traffic). You'll create one List and one Rule that references it.
+
+1. Open the Cloudflare account-level dashboard (the home dashboard, not a specific zone).
+2. Navigate to **Bulk Redirects** in the left sidebar. As of late 2025 this lives under **Rules → Redirect Rules → Bulk Redirects** at the account level. The exact path may move; search "Bulk Redirects" if it's not where expected.
+3. Click **Create a Bulk Redirect List**.
+4. **Name:** `mlaify-io-sunset`
+5. **Description:** `Phase 3 of matthewd.xyz × mlaify merge — 301 mlaify.io paths to matthewd.xyz`
+6. Click **Upload CSV** (or "import file"; the wording varies) and select `cloudflare-redirects-mlaify-io.csv`.
+7. Cloudflare validates each row. If any are rejected, the most common cause is column-header drift between when the CSV was written and the current Cloudflare schema. Fix as follows:
+   - Open the CSV in a text editor.
+   - Compare the header row against Cloudflare's expected schema (shown in the upload dialog).
+   - Rename columns or normalize boolean values (`true` → `Yes`, etc.) to match.
+   - Re-save and re-upload.
+8. Click **Save** once all 16 rules validate.
+
+## Step 3: Create the Bulk Redirect Rule that applies the list
+
+1. Back in **Bulk Redirects**, click **Create a Bulk Redirect Rule** (sometimes called "Create rule").
+2. **Name:** `mlaify-io-sunset-rule`
+3. **List:** select `mlaify-io-sunset` from the dropdown.
+4. **Action:** ensure it's set to `Redirect`.
+5. Click **Deploy** (or "Save and deploy").
+
+The rule is now active on Cloudflare's edge. Propagation is typically under 30 seconds.
+
+## Step 4: Smoke-test the redirects
+
+In a terminal:
+
+```bash
+for path in / /aegis/ /aegis/architecture/ /attackmap/ /attackmap/analyzers/ /docs/project-omekarapper/ /docs/project-opensift/ /docs/project-opencontractrx/ /build-principles/ /contribute/ /about/ /privacy/ /security/ /humans.txt /.well-known/security.txt /privacy.json; do
+  echo "--- mlaify.io$path ---"
+  curl -sI "https://mlaify.io$path" -o /tmp/h.txt
+  grep -iE "HTTP|^location:" /tmp/h.txt | tr -d '\r' | head -2
+done
+```
+
+Expected for every entry:
+```
+HTTP/2 301
+location: https://matthewd.xyz/<rewritten-path>
+```
+
+If any rule misses (you see a 200 or the wrong location), open the Cloudflare dashboard → Bulk Redirects → the List, and check that entry's settings. The most common causes:
+- `subpath_matching` toggle not enabled when it should be.
+- `preserve_path_suffix` toggle not enabled.
+- Source URL has a different trailing slash than what was uploaded.
+
+## Step 5: Remove DNS records for opensift.org and siftbook.org
+
+Both side domains were CNAME'd at GitHub Pages via the mlaify.github.io repo's CNAME file. After plan Task 4 trims that CNAME, those domains stop being claimed by GH Pages. The DNS records also need removing.
+
+For each zone (`opensift.org` and then `siftbook.org`):
+
+1. Open the zone in Cloudflare → **DNS** → **Records**.
+2. Identify the CNAME or A records pointing at GitHub Pages. Typical patterns:
+   - CNAME → `<username>.github.io` or `mlaify.github.io`
+   - A records → `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153` (GitHub Pages IP block)
+3. Click **Edit** → **Delete** for each record.
+
+The domain will start returning DNS errors for HTTP requests within a few minutes (subject to TTL on cached lookups). If you want to keep the registration but make the site inactive, that's enough. If you want to fully release, also let the registration lapse at your registrar.
+
+## Step 6: Validate side domains are gone
+
+```bash
+curl -sI https://opensift.org/ 2>&1 | head -3
+curl -sI https://siftbook.org/ 2>&1 | head -3
+```
+
+Expected: connection failure (`Could not resolve host`) or a Cloudflare error page. Either is acceptable — the domains are no longer serving mlaify content.
+
+If you still see a 200/301 response after several minutes, DNS removal didn't take — re-check Step 5.
+
+## Step 7: Final mlaify.io smoke
+
+```bash
+curl -sIL https://mlaify.io/anything-not-in-the-rules | grep -iE "HTTP|^location:" | tr -d '\r' | head
+```
+
+Expected: 301 to `https://matthewd.xyz/anything-not-in-the-rules` (the catchall preserves the path suffix). If the catchall was deployed as exact-match instead, the location will be `https://matthewd.xyz/projects/` — also acceptable for a sunset.
+
+## When you're done
+
+Reply in chat with the output of Steps 4 and 6 (or just "redirects done, side domains gone"). I'll proceed with Task 4 (trim mlaify.github.io CNAME + archived notice), Task 6 (`gh repo archive`), and Task 7 (PR + CHANGELOG).
+
+If anything in this runbook doesn't match Cloudflare's current UI, paste the discrepancy and I'll update the runbook before you proceed.

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,7 +1,10 @@
-matthewd.org
 matthewd.xyz
-callmemattd.com
-littleabigails.com
+matthewd.org
+fhrp.org
+mlaify.io
 mdavis.me
 mldavis.me
 mlphotography.me
+rightsarchived.org
+rightsinfocus.org
+tffhrtp.org


### PR DESCRIPTION
## Summary

Final phase of the matthewd.xyz × mlaify merge. Documents and verifies the Cloudflare redirect setup, adds defensive Hugo aliases for the cases Cloudflare can't handle, updates matthewd's CNAME to the new 10-domain set, and archives the mlaify repo.

### What lands in this PR (matthewd.xyz repo)

- **Cloudflare Bulk Redirects CSV** at `docs/superpowers/ops/cloudflare-redirects-mlaify-io.csv` — 16 rules for mlaify.io paths.
- **Runbook** at `docs/superpowers/ops/phase-3-runbook.md` — self-contained manual Cloudflare procedure.
- **CNAME update** — new 10-domain set: matthewd.xyz, matthewd.org, fhrp.org, mlaify.io, mdavis.me, mldavis.me, mlphotography.me, rightsarchived.org, rightsinfocus.org, tffhrtp.org. mlaify.io is now claimed by this repo's GH Pages (so mlaify repo could be archived).
- **Hugo aliases** for the 5 path-rewriting cases Cloudflare Bulk Redirects can't handle:
  - `/build-principles/` → `/principles/`
  - `/docs/project-omekarapper/` → `/omekarapper/`
  - `/docs/project-opensift/` → `/opensift/`
  - `/docs/project-opencontractrx/` → `/opencontractrx/`
  - `/docs/projects/`, `/docs/` → `/projects/`
  - `/privacy/` → `/privacy-policy/`
- **CHANGELOG** entry covering Phase 3.

### What landed outside this PR

- **mlaify/mlaify.github.io repo:** CNAME removed, homepage replaced with "moved" notice, repo **archived**.
- **Cloudflare:** Bulk Redirects List `mlaify-io-sunset` deployed; opensift.org and siftbook.org DNS records removed (per user).

### Discovery during execution

Cloudflare's Bulk Redirects feature **does not rewrite paths** — even with `subpath_matching=false` and `preserve_path_suffix=false`, it preserves the source URL's path and only swaps the host. This means rules like `mlaify.io/build-principles/` → `matthewd.xyz/principles/` actually resolve to `matthewd.xyz/build-principles/` after the Cloudflare 301. The Hugo `aliases` in this PR catch those rewritten URLs at matthewd's side and emit a second 301 to the canonical path. Total of two 301 hops for those URLs — not ideal, but no 404s for the most-trafficked old URLs.

For future path-rewrite needs, Cloudflare **Single Redirects** (not Bulk) with wildcard targets is the proper feature.

### Test plan

- [ ] CI passes
- [ ] All 16 mlaify.io URLs return some flavor of 301 → matthewd.xyz
- [ ] After merge, the 5 alias URLs (`/build-principles/`, etc.) emit second-hop 301s to canonical paths
- [ ] matthewd.xyz routes still serve correctly after the CNAME / Hugo-aliases changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)