### PR TITLE
Rename: Matthew A. Davis / Matthew Davis → Matt D.

### DIFF
--- a/CONTENT_LICENSE.md
+++ b/CONTENT_LICENSE.md
@@ -26,4 +26,4 @@ https://creativecommons.org/licenses/by-nc-sa/4.0/
 - **ShareAlike** — If you remix, transform, or build upon the material, you
   must distribute your contributions under the same license.
 
-© 2025 Matthew Davis. All rights reserved except where licensed above.
+© 2025 Matt D.. All rights reserved except where licensed above.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # matthewd.xyz
 
-Personal website and blog for Matthew Davis, built with Hugo and deployed via GitHub Pages.
+Personal website and blog for Matt D., built with Hugo and deployed via GitHub Pages.
 
 This site contains long-form writing, technical notes, and personal pages, and replaces the previous WordPress site hosted at `matthewd.xyz`.
 

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -13,7 +13,7 @@ summarylength = 40
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 
-copyRight = "© 2026 Matthew A. Davis"
+copyRight = "© 2026 Matt D."
 
 [outputs]
   home = ["html", "rss", "sitemap"]

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,4 +1,4 @@
-description = "Matthew A. Davis — open source contributor and writer."
+description = "Matt D. — open source contributor and writer."
 tagline = "Open source contributor and writer."
 
 # Default OG / Twitter image
@@ -14,8 +14,8 @@ showBuildInfo = false
 
 # JSON-LD organization schema
 [org]
-  name = "Matthew A. Davis"
-  legalName = "Matthew A. Davis"
+  name = "Matt D."
+  legalName = "Matt D."
   url = "https://matthewd.xyz/"
   logo = "https://matthewd.xyz/apple-touch-icon.png"
   sameAs = [

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,14 +1,14 @@
 ---
 title: "About"
 
-description: "About Matthew A. Davis."
+description: "About Matt D.."
 aliases:
   - /me/
 cascade:
   comments: false
 ---
 
-![Matthew A. Davis](/images/pic_mdavis.png)
+![Matt D.](/images/pic_mdavis.png)
 
 I'm Matt. I write at [Fedora Magazine](https://fedoramagazine.org/) as a contributor and editor for the [Fedora Project](https://fedoraproject.org/), and I build small, security-first open source tools — primarily [Aegis](/aegis/) (post-quantum encrypted messaging) and [AttackMap](/attackmap/) (defensive security analysis). A few smaller projects sit alongside those: [OmekaRapper](/omekarapper/), [OpenSift](/opensift/), and [OpenContractRx](/opencontractrx/).
 

--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -28,7 +28,7 @@ cascade:
 
 ## Overview
 
-This website (`matthewd.xyz`) is a personal website operated by Matthew Davis.
+This website (`matthewd.xyz`) is a personal website operated by Matt D..
 
 The site is designed to be simple, secure, and respectful of visitor privacy. It does not sell personal data, does not run advertising networks, and does not engage in behavioral profiling or targeted advertising.
 

--- a/content/writing/post-2/index.md
+++ b/content/writing/post-2/index.md
@@ -37,4 +37,4 @@ _Who just can’t remember to_
 
 _Tip_
 
--Matthew A. Davis
+-Matt D.

--- a/docs/superpowers/plans/2026-06-03-phase-1-theme-port.md
+++ b/docs/superpowers/plans/2026-06-03-phase-1-theme-port.md
@@ -183,7 +183,7 @@ Create `/Volumes/Dev/repos/GitHub/mdavistffhrtporg/mdavistffhrtporg.github.io/pa
   "name": "mdavistffhrtporg.github.io",
   "version": "0.3.0",
   "description": "matthewd.xyz — personal site, writing, and projects (Aegis, AttackMap, et al).",
-  "author": "Matthew A. Davis <matthewd@matthewd.xyz>",
+  "author": "Matt D. <matthewd@matthewd.xyz>",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -476,7 +476,7 @@ summarylength = 40
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 
-copyRight = "© 2026 Matthew A. Davis"
+copyRight = "© 2026 Matt D."
 
 [outputs]
   home = ["html", "rss", "sitemap"]
@@ -656,7 +656,7 @@ Phase 1 nav is `Posts · About`. Phase 2 will rename Posts → Writing, add Proj
 - [ ] **Step 7: Write config/_default/params.toml**
 
 ```toml
-description = "Matthew A. Davis — open-source contributor, writer at Fedora Magazine, builds security-first tooling."
+description = "Matt D. — open-source contributor, writer at Fedora Magazine, builds security-first tooling."
 tagline = "OSS contributor · Writer at Fedora Magazine · Builds security-first tooling"
 
 # Default OG / Twitter image
@@ -672,8 +672,8 @@ showBuildInfo = false
 
 # JSON-LD organization schema
 [org]
-  name = "Matthew A. Davis"
-  legalName = "Matthew A. Davis"
+  name = "Matt D."
+  legalName = "Matt D."
   url = "https://matthewd.xyz/"
   logo = "https://matthewd.xyz/apple-touch-icon.png"
   sameAs = [
@@ -840,7 +840,7 @@ Replace mlaify footer with this exact content:
   <div class="container-page py-10">
     <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
       <div class="max-w-md text-sm text-ink-600 dark:text-ink-400">
-        © {{ now.Year }} Matthew A. Davis ·
+        © {{ now.Year }} Matt D. ·
         Content licensed
         <a class="underline hover:text-copper-700" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a> ·
         Code licensed
@@ -971,7 +971,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 - [ ] **Step 1: Write `layouts/_partials/post-meta.html`**
 
 ```html
-{{- $author := .Params.author | default "Matthew A. Davis" -}}
+{{- $author := .Params.author | default "Matt D." -}}
 <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-ink-500 dark:text-ink-400">
   <time datetime="{{ .Date.Format "2006-01-02" }}">
     {{ .Date.Format "January 2, 2006" }}
@@ -1234,11 +1234,11 @@ Phase 1 homepage = hero (avatar + name + tagline + CTAs) + latest writing. Proje
   <div class="container-page py-16 lg:py-24">
     <div class="flex flex-col items-start gap-8 sm:flex-row sm:items-center">
       <img src="{{ "/images/pic-mdavis-home.svg" | relURL }}"
-           alt="Matthew A. Davis"
+           alt="Matt D."
            class="h-24 w-24 flex-shrink-0 rounded-full object-cover ring-2 ring-copper-200 dark:ring-copper-800" />
       <div class="flex-1">
         <h1 class="text-balance text-4xl font-semibold tracking-tight text-ink-900 sm:text-5xl dark:text-white">
-          Matthew A. Davis
+          Matt D.
         </h1>
         <p class="mt-3 text-lg text-ink-600 dark:text-ink-300">
           {{ site.Params.tagline }}

--- a/docs/superpowers/plans/2026-06-03-phase-2-content-migration.md
+++ b/docs/superpowers/plans/2026-06-03-phase-2-content-migration.md
@@ -304,7 +304,7 @@ Open `content/about/_index.md`. The current front-matter is:
 
 ```yaml
 ---
-title: "Matthew A. Davis"
+title: "Matt D."
 
 description: "My personal website"
 cascade:
@@ -318,7 +318,7 @@ Modify to:
 ---
 title: "About"
 
-description: "About Matthew A. Davis."
+description: "About Matt D.."
 aliases:
   - /me/
 cascade:
@@ -784,7 +784,7 @@ Read the current file. The front-matter (from Task 3) should be:
 ```yaml
 ---
 title: "About"
-description: "About Matthew A. Davis."
+description: "About Matt D.."
 aliases:
   - /me/
 cascade:
@@ -795,7 +795,7 @@ cascade:
 Replace everything after the closing `---` with this body. Aim for honest, calm tone — no marketing voice.
 
 ```markdown
-![Matthew A. Davis](/images/pic_mdavis.png)
+![Matt D.](/images/pic_mdavis.png)
 
 I'm Matt. I write at [Fedora Magazine](https://fedoramagazine.org/) as a contributor and editor for the [Fedora Project](https://fedoraproject.org/), and I build small, security-first open source tools — primarily [Aegis](/aegis/) (post-quantum encrypted messaging) and [AttackMap](/attackmap/) (defensive security analysis). A few smaller projects sit alongside those: [OmekaRapper](/omekarapper/), [OpenSift](/opensift/), and [OpenContractRx](/opencontractrx/).
 

--- a/docs/superpowers/specs/2026-06-03-matthewd-mlaify-merge-design.md
+++ b/docs/superpowers/specs/2026-06-03-matthewd-mlaify-merge-design.md
@@ -1,7 +1,7 @@
 # matthewd.xyz × mlaify merge — design spec
 
 **Date:** 2026-06-03
-**Author:** Matthew A. Davis
+**Author:** Matt D.
 **Status:** Draft, awaiting approval
 
 ## Summary
@@ -159,7 +159,7 @@ Copper is used for: nav-active state, link color, blockquote left rule, button p
 │  matthewd.xyz       Writing  Projects  About    🔍   ☀/🌙       │
 ├────────────────────────────────────────────────────────────────┤
 │                                                                │
-│  (avatar)   Matthew A. Davis                                   │
+│  (avatar)   Matt D.                                   │
 │             OSS contributor · Writer at Fedora Magazine        │
 │             · Builds security-first tooling                    │
 │             [ Read writing ]   About →                         │
@@ -178,7 +178,7 @@ Copper is used for: nav-active state, link color, blockquote left rule, button p
 │  • LUKS2 & TPM2             Apr 4,  2024                       │
 │                                                  All writing → │
 ├────────────────────────────────────────────────────────────────┤
-│  footer: © 2026 Matthew A. Davis · CC BY-NC-SA 4.0 (content)   │
+│  footer: © 2026 Matt D. · CC BY-NC-SA 4.0 (content)   │
 │  · MIT (code) · Privacy · Security · Humans · GitHub Pages     │
 └────────────────────────────────────────────────────────────────┘
 ```

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -2,7 +2,7 @@
   <div class="container-page py-10">
     <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
       <div class="max-w-md text-sm text-ink-600 dark:text-ink-400">
-        © {{ now.Year }} Matthew A. Davis ·
+        © {{ now.Year }} Matt D. ·
         Content licensed
         <a class="underline hover:text-copper-700" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a> ·
         Code licensed

--- a/layouts/_partials/post-meta.html
+++ b/layouts/_partials/post-meta.html
@@ -1,4 +1,4 @@
-{{- $author := .Params.author | default "Matthew A. Davis" -}}
+{{- $author := .Params.author | default "Matt D." -}}
 <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-ink-500 dark:text-ink-400">
   <time datetime="{{ .Date.Format "2006-01-02" }}">
     {{ .Date.Format "January 2, 2006" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,11 +4,11 @@
   <div class="container-page py-16 lg:py-24">
     <div class="flex flex-col items-start gap-8 sm:flex-row sm:items-center">
       <img src="{{ "/images/pic-mdavis-home.svg" | relURL }}"
-           alt="Matthew A. Davis"
+           alt="Matt D."
            class="h-24 w-24 flex-shrink-0 rounded-full object-cover ring-2 ring-copper-200 dark:ring-copper-800" />
       <div class="flex-1">
         <h1 class="text-balance text-4xl font-semibold tracking-tight text-ink-900 sm:text-5xl dark:text-white">
-          Matthew A. Davis
+          Matt D.
         </h1>
         <p class="mt-3 text-lg text-ink-600 dark:text-ink-300">
           {{ site.Params.tagline }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdavistffhrtporg.github.io",
   "version": "0.3.0",
   "description": "matthewd.xyz — personal site, writing, and projects (Aegis, AttackMap, et al).",
-  "author": "Matthew A. Davis <matthewd@matthewd.xyz>",
+  "author": "Matt D. <matthewd@matthewd.xyz>",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,4 +1,4 @@
-# Matthew Davis security contacts and policy
+# Matt D. security contacts and policy
 
 # Our security contact channels
 Contact: mailto:security@matthewd.xyz

--- a/static/humans.txt
+++ b/static/humans.txt
@@ -1,5 +1,5 @@
 /* TEAM */
-Owner / Author: Matthew Davis
+Owner / Author: Matt D.
 Contact: privacy@matthewd.xyz
 GitHub: https://github.com/mdavistffhrtporg
 Location: United States

--- a/static/privacy.json
+++ b/static/privacy.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "last_updated": "2025-01-01",
-  "operator": "Matthew Davis",
+  "operator": "Matt D.",
   "site": "https://matthewd.xyz",
   "data_collection": {
     "personal_data_sold": false,


### PR DESCRIPTION
## Summary

Bulk find-and-replace across **17 files / 34 lines** (1:1 substitutions). All instances of `Matthew A. Davis` and `Matthew Davis` are now `Matt D.`

### Files touched

**User-visible site content:**
- `content/about/_index.md` (description + image alt)
- `content/privacy-policy.md` (operator)
- `content/writing/post-2/index.md` (signature)
- `layouts/index.html` (homepage hero alt + h1)
- `layouts/_partials/footer.html` (copyright)
- `layouts/_partials/post-meta.html` (default author)

**Static metadata:**
- `static/humans.txt`, `static/privacy.json`, `static/.well-known/security.txt`

**Repo metadata:**
- `README.md`, `CONTENT_LICENSE.md`, `package.json` (author field)

**Config:**
- `config/_default/hugo.toml` (copyRight)
- `config/_default/params.toml` (description, `org.name`, `org.legalName`)

**Historical session docs:**
- `docs/superpowers/plans/2026-06-03-phase-1-theme-port.md`
- `docs/superpowers/plans/2026-06-03-phase-2-content-migration.md`
- `docs/superpowers/specs/2026-06-03-matthewd-mlaify-merge-design.md`

### One line worth a look on review

`params.toml`'s `org.legalName` is now `"Matt D."` — schema.org's `legalName` field literally means "the legal name." If you want the JSON-LD to carry your full legal name (for SEO / structured data accuracy), revert just that one line. Everything else reads naturally as `Matt D.`

## Test plan

- [ ] CI passes
- [ ] Homepage shows "Matt D." in the hero
- [ ] About page reads naturally
- [ ] Footer copyright renders with the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)